### PR TITLE
Add model validation

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,9 +12,13 @@ class TasksController < ApplicationController
   end
 
   def create
-    task = Task.new(task_params)
-    task.save!
-    redirect_to tasks_path, notice: "「#{task.name}」を登録しました٩( 'ω' )و"
+    @task = Task.new(task_params)
+
+    if @task.save
+      redirect_to @tasks, notice: "「#{task.name}」を登録しました٩( 'ω' )و"
+    else
+      render :new
+    end
   end
 
   def edit

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,4 +3,11 @@
 class Task < ApplicationRecord
   validates :name, presence: true
   validates :name, length: { maximum: 20 }
+  validate :validate_name_not_including_comma
+
+  private
+
+  def validate_name_not_including_comma
+    errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  validates :name, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,5 @@
 
 class Task < ApplicationRecord
   validates :name, presence: true
+  validates :name, length: { maximum: 20 }
 end

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,3 +1,8 @@
+- if task.errors.present?
+  ul#error_explanation
+    - task.errors.full_messages.each do |message|
+      li= message
+      
 = form_with model: task, local: true do |f|
   .form-group
     = f.label '名前'


### PR DESCRIPTION
## メモ
name属性に`,`を含まないようにするバリデーションは、formatヘルパーを使うと自分でメソッド定義しなくても実装できる